### PR TITLE
Fallback to :response_body if :body is not set (faraday 1.0 support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ notifications:
     secure: Ri3bGJvNKfZ6ynbHcbICknWaAJFbQPlGQE9YSY9xMB7rGomsofY4yS8yf17WlSTd2MqxhzMXgbqXfkQW759Opknw75URo8tLTnSlpJsVSqV7T4dUsfNZguyQElVZMxYacFbBZEJGBdz2Ra6xbMBdg8NqVACb65I2xeK2fsvm77k=
 gemfile:
   - gemfiles/Gemfile.faraday-0.8
+  - gemfiles/Gemfile.faraday-1.0
   - Gemfile

--- a/faraday-http-cache.gemspec
+++ b/faraday-http-cache.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.executables   = []
 
   gem.required_ruby_version = '>= 2.1.0'
-  gem.add_dependency 'faraday', '~> 0.8'
+  gem.add_dependency 'faraday', '>= 0.8'
 end

--- a/gemfiles/Gemfile.faraday-1.0
+++ b/gemfiles/Gemfile.faraday-1.0
@@ -1,0 +1,12 @@
+source 'http://rubygems.org'
+
+gem 'faraday-http-cache', path: '..'
+
+gem 'faraday',            '1.0.0'
+gem 'faraday_middleware', '1.0.0.rc1'
+
+gem 'em-http-request',    '~> 1.1'
+gem 'rspec',              '~> 3.1'
+gem 'rake',               '~> 12.0'
+gem 'activesupport',      '>= 5.0'
+gem 'sinatra',            '~> 2.0'

--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -297,7 +297,7 @@ module Faraday
 
       {
         status: hash[:status],
-        body: hash[:body],
+        body: hash[:body] || hash[:response_body],
         response_headers: hash[:response_headers]
       }
     end


### PR DESCRIPTION
~Faraday 0.16.x changed the key names, this should allow us to support
both 0.15.x and 0.16.x for now.~ (reverted in 0.17.x)

Adds backwards-compatible support for Faraday 1.0.

Other alternatives to fix are to remove the call to `.to_hash` and access directly with `#[]`, or to call `#body`.

The prefered solution appears to be to use [`#body`](https://github.com/lostisland/faraday/pull/847#pullrequestreview-205796972). However, there is some benefit in being explicit I suppose - please let me know what you would prefer.

Closes: #114 
Related: lostisland/faraday#847

---

Edit: Updated for `faraday-1.0.0`