### PR TITLE
README: Use the "sourcelevel" user in build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Faraday Http Cache
 
-[![Build Status](https://secure.travis-ci.org/plataformatec/faraday-http-cache.svg?branch=master)](https://travis-ci.org/plataformatec/faraday-http-cache)
+[![Build Status](https://secure.travis-ci.org/sourcelevel/faraday-http-cache.svg?branch=master)](https://travis-ci.org/sourcelevel/faraday-http-cache)
 
 a [Faraday](https://github.com/lostisland/faraday) middleware that respects HTTP cache,
 by checking expiration and validation of the stored responses.


### PR DESCRIPTION
This PR completes the repository move by changing the user in the Travis CI build badge.