### PR TITLE
Add support for Ruby 3.0+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,14 +19,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7']
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
         faraday_adapter: [net_http, em_http]
-        faraday: [ '~> 0.8.0', '~> 0.15.0', '~> 0.17.3', '~> 1.0', '~> 2.0' ]
+        faraday: ['~> 0.8.0', '~> 0.15.0', '~> 0.17.3', '~> 1.0', '~> 2.0']
         exclude:
+          # Faraday 2 requires Ruby 2.6+
           - ruby: '2.5'
             faraday: '~> 2.0'
           - ruby: '2.4'
             faraday: '~> 2.0'
+          # Ruby 3.0+ requires Faraday >= 0.17.3
+          - ruby: '3.0'
+            faraday: '~> 0.8.0'
+          - ruby: '3.0'
+            faraday: '~> 0.15.0'
+          - ruby: '3.1'
+            faraday: '~> 0.8.0'
+          - ruby: '3.1'
+            faraday: '~> 0.15.0'
+          # faraday-em_http does not support Faraday 2.0+
           - faraday: '~> 2.0'
             faraday_adapter: em_http
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Added support for Ruby 3.0, 3.1.
+* Ruby version constraint changed to 2.4.0.
+
 ## 2.2.0 (2019-04-13)
 
 * Support for faraday 1.x

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,6 @@ gem 'em-http-request',    '~> 1.1'
 gem 'rake',               '~> 13.0'
 gem 'rspec',              '~> 3.1'
 gem 'sinatra',            '~> 2.0'
+gem 'webrick'
 
 eval_gemfile 'gemfiles/rubocop.gemfile'

--- a/faraday-http-cache.gemspec
+++ b/faraday-http-cache.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.executables   = []
 
-  gem.required_ruby_version = '>= 2.1.0' # rubocop:disable Gemspec/RequiredRubyVersion
+  gem.required_ruby_version = '>= 2.4.0'
   gem.add_dependency 'faraday', '>= 0.8'
 end

--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -100,14 +100,21 @@ module Faraday
     #   # Initialize the middleware with a MemoryStore and logger
     #   store = ActiveSupport::Cache.lookup_store
     #   Faraday::HttpCache.new(app, store: store, logger: my_logger)
-    def initialize(app, store: nil, serializer: nil, shared_cache: true, instrumenter: nil, instrument_name: EVENT_NAME, logger: nil) # rubocop:disable Metrics/ParameterLists
+    def initialize(app, options = {})
       super(app)
 
-      @logger = logger
-      @shared_cache = shared_cache
-      @instrumenter = instrumenter
-      @instrument_name = instrument_name
-      @storage = Storage.new(store: store, serializer: serializer, logger: logger)
+      options = options.dup
+      @logger = options.delete(:logger)
+      @shared_cache = options.delete(:shared_cache) { true }
+      @instrumenter = options.delete(:instrumenter)
+      @instrument_name = options.delete(:instrument_name) { EVENT_NAME }
+
+      store = options.delete(:store)
+      serializer = options.delete(:serializer)
+
+      raise ArgumentError, "Unknown options: #{options.inspect}" unless options.empty?
+
+      @storage = Storage.new(store: store, serializer: serializer, logger: @logger)
     end
 
     # Public: Process the request into a duplicate of this instance to

--- a/lib/faraday/http_cache/storage.rb
+++ b/lib/faraday/http_cache/storage.rb
@@ -168,7 +168,7 @@ module Faraday
       end
 
       def warn(message)
-        @logger.warn(message) if @logger # rubocop:disable Style/SafeNavigation
+        @logger&.warn(message)
       end
     end
 

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -44,7 +44,7 @@ describe Faraday::HttpCache::Storage do
       let(:serializer) { JSON }
       it_behaves_like 'A storage with serialization'
 
-      context 'when ASCII characters in response cannot be converted to UTF-8' do
+      context 'when ASCII characters in response cannot be converted to UTF-8', if: Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1') do
         let(:response) do
           body = String.new("\u2665").force_encoding('ASCII-8BIT')
           double(:response, serializable_hash: { 'body' => body })

--- a/spec/support/test_server.rb
+++ b/spec/support/test_server.rb
@@ -32,7 +32,7 @@ class TestServer
         Logger: WEBrick::Log.new(log),
         AccessLog: [[log, '[%{X-Faraday-Adapter}i] %m  %U  ->  %s %b']]
       }
-      Rack::Handler::WEBrick.run(TestApp, webrick_opts)
+      Rack::Handler::WEBrick.run(TestApp, **webrick_opts)
     end
   end
 
@@ -63,6 +63,6 @@ class TestServer
     server = TCPServer.new(@host, 0)
     server.addr[1]
   ensure
-    server.close if server # rubocop:disable Style/SafeNavigation
+    server&.close
   end
 end


### PR DESCRIPTION
This PR:
- adds support for Ruby 3.0, 3.1
- drops support for Ruby < 2.4

Part of #127 and successor for #122