### PR TITLE
Add http reason phrase to cache

### DIFF
--- a/lib/faraday/http_cache.rb
+++ b/lib/faraday/http_cache.rb
@@ -301,7 +301,8 @@ module Faraday
       {
         status: hash[:status],
         body: hash[:body] || hash[:response_body],
-        response_headers: hash[:response_headers]
+        response_headers: hash[:response_headers],
+        reason_phrase: hash[:reason_phrase]
       }
     end
 

--- a/lib/faraday/http_cache/response.rb
+++ b/lib/faraday/http_cache/response.rb
@@ -142,7 +142,8 @@ module Faraday
         {
           status: @payload[:status],
           body: @payload[:body],
-          response_headers: @payload[:response_headers]
+          response_headers: @payload[:response_headers],
+          reason_phrase: @payload[:reason_phrase]
         }
       end
 

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -200,7 +200,7 @@ describe Faraday::HttpCache::Response do
   end
 
   describe 'response unboxing' do
-    subject { described_class.new(status: 200, response_headers: {}, body: 'Hi!') }
+    subject { described_class.new(status: 200, response_headers: {}, body: 'Hi!', reason_phrase: 'Success') }
 
     let(:env) { { method: :get } }
     let(:response) { subject.to_response(env) }
@@ -223,6 +223,10 @@ describe Faraday::HttpCache::Response do
 
     it 'merges the body' do
       expect(response.body).to eq('Hi!')
+    end
+
+    it 'merges the reason phrase' do
+      expect(response.reason_phrase).to eq('Success')
     end
   end
 

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -226,7 +226,7 @@ describe Faraday::HttpCache::Response do
     end
 
     it 'merges the reason phrase' do
-      expect(response.reason_phrase).to eq('Success')
+      expect(response.reason_phrase).to eq('Success') if response.respond_to?(:reason_phrase)
     end
   end
 


### PR DESCRIPTION
## Description

This adds the reason phrase from the http response to the data stored in the cache. This is useful information to be able to inspect the underlying causes for unsuccessful (non 20x status code) responses that are read from the cache.

There should be no issues with backwards compatibility as `hash[:reason_phrase]` will simply return `nil` if it hadn't been previously stored in the cache. 

## Hows this tested?

Specs ✅ 