### PR TITLE
Protect against {boolean}.to_i raising on invalid stale-while-revalidate cache control directives

### DIFF
--- a/lib/faraday/http_cache/cache_control.rb
+++ b/lib/faraday/http_cache/cache_control.rb
@@ -70,9 +70,13 @@ module Faraday
 
       # Internal: Gets the 'stale-while-revalidate' directive as an Integer.
       #
-      # Returns nil if the 'stale-while-revalidate' directive isn't present.
+      # Returns nil if the 'stale-while-revalidate' directive isn't present, or
+      # assigned as boolean.
       def stale_while_revalidate
-        @directives['stale-while-revalidate'].to_i if @directives.key?('stale-while-revalidate')
+        return unless @directives.key?('stale-while-revalidate')
+        return if @directives['stale-while-revalidate'] == true
+
+        @directives['stale-while-revalidate'].to_i
       end
 
       # Internal: Gets the String representation for the cache directives.

--- a/spec/cache_control_spec.rb
+++ b/spec/cache_control_spec.rb
@@ -116,4 +116,14 @@ describe Faraday::HttpCache::CacheControl do
     cache_control = Faraday::HttpCache::CacheControl.new('public, max-age=60')
     expect(cache_control.stale_while_revalidate).to be_nil
   end
+
+  it 'responds to #stale_while_revalidate with 0 when directive is invalid true string value' do
+    cache_control = Faraday::HttpCache::CacheControl.new('public, max-age=60, stale-while-revalidate=true')
+    expect(cache_control.stale_while_revalidate).to eq(0)
+  end
+
+  it 'responds to #stale_while_revalidate with nil when directive has no integer assignment' do
+    cache_control = Faraday::HttpCache::CacheControl.new('public, max-age=60, stale-while-revalidate')
+    expect(cache_control.stale_while_revalidate).to be_nil
+  end
 end


### PR DESCRIPTION
Invalid cache control directives for `stale-while-revalidate` are raising [here](https://github.com/matthutchinson/faraday-http-cache/blob/master/lib/faraday/http_cache/cache_control.rb#L75) when we attempt to parse the integer value.  

Eg. an invalid cache-control directive such as this

    public, max-age=60, stale-while-revalidate

The gem converts directives without values to `true` [here](https://github.com/matthutchinson/faraday-http-cache/blob/master/lib/faraday/http_cache/cache_control.rb#L122). 

This PR will allow the gem to ignore these invalid values (see [spec](https://datatracker.ietf.org/doc/html/rfc5861#section-3)), and prevent this error from raising;

    [NoMethodError] undefined method 'to_i' for true

Added tests to verify behaviour.